### PR TITLE
Require a non-* targetOrigin when delegating a capability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ the browser enforce the user activation requirement, as follows:
 ```javascript
 // Top-frame (merchant website) code
 checkout_button.onclick = () => {
-    targetWindow.postMessage("process_payment", {delegate: "payment"});
+    targetWindow.postMessage("process_payment", {targetOrigin: "https://example.com",
+                                                 delegate: "payment"
+                                                });
 };
 
 // Sub-frame (PSP website) code
@@ -95,8 +97,10 @@ provides a solution:
 let win1 = open("presentation1.html");
 let win2 = open("presentation2.html");
 
-button1.onclick = () => win1.postMessage("msg", {delegate: "fullscreen"});
-button2.onclick = () => win2.postMessage("msg", {delegate: "fullscreen"});
+button1.onclick = () => win1.postMessage("msg", {targetOrigin: "https://example.com",
+                                                 delegate: "fullscreen"});
+button2.onclick = () => win2.postMessage("msg", {targetOrigin: "https://example.com",
+                                                 delegate: "fullscreen"});
 
 // Sub-frame ("presentation window") code
 window.onmessage = () => document.body.requestFullscreen();

--- a/example/payment-request/index.html
+++ b/example/payment-request/index.html
@@ -6,16 +6,15 @@
     <title>Payment request example</title>
     <script>
       function init() {
+          let target_origin = "https://egirard.github.io";
+
           document.getElementById("button0").addEventListener("click", e => {
-              frames[0].postMessage("checkout", {targetOrigin: "*"});
+              frames[0].postMessage("checkout", {targetOrigin: target_origin});
           });
-          // The option "createToken" is there to make the experimental API in
-          // older Chrome work.
+
           document.getElementById("button1").addEventListener("click", e => {
-              frames[0].postMessage("checkout", {targetOrigin: "*",
-                                                 delegate: "paymentrequest",
-                                                 createToken: "paymentrequest"
-                                                });
+              frames[0].postMessage("checkout", {targetOrigin: target_origin,
+                                                 delegate: "paymentrequest"});
           });
       }
     </script>

--- a/spec.bs
+++ b/spec.bs
@@ -145,13 +145,16 @@ will be followed by two additional steps as follows:
 
 8. If <var>delegate</var> is not null, then:
 
-    1. If <var>targetWindow</var> has [transient
+    1. If <var>targetOrigin</var> is a single U+002A ASTERISK character (*), then throw a
+        a "NotAllowedError" DOMException and return.
+
+    2. If <var>targetWindow</var> has [transient
         activation](https://html.spec.whatwg.org/multipage/interaction.html#transient-activation),
         then [consume user
         activation](https://html.spec.whatwg.org/multipage/interaction.html#consume-user-activation)
         in <var>targetWindow</var>.
 
-    2. Otherwise, let <var>delegate</var> be null.
+    3. Otherwise, let <var>delegate</var> be null.
 
 
 # Tracking delegated capability # {#tracking-delegation}

--- a/spec.bs
+++ b/spec.bs
@@ -146,7 +146,7 @@ will be followed by two additional steps as follows:
 8. If <var>delegate</var> is not null, then:
 
     1. If <var>targetOrigin</var> is a single U+002A ASTERISK character (*), then throw a
-        a "NotAllowedError" DOMException and return.
+        a "NotAllowedError" DOMException.
 
     2. If <var>targetWindow</var> has [transient
         activation](https://html.spec.whatwg.org/multipage/interaction.html#transient-activation),

--- a/spec.bs
+++ b/spec.bs
@@ -154,7 +154,7 @@ will be followed by two additional steps as follows:
         activation](https://html.spec.whatwg.org/multipage/interaction.html#consume-user-activation)
         in <var>targetWindow</var>.
 
-    3. Otherwise, let <var>delegate</var> be null.
+    3. Otherwise, set <var>delegate</var> to null.
 
 
 # Tracking delegated capability # {#tracking-delegation}

--- a/spec.html
+++ b/spec.html
@@ -6,7 +6,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version 5c7bc9381, updated Wed May 12 18:18:08 2021 -0700" name="generator">
   <link href="https://wicg.github.io/capability-delegation/spec.html" rel="canonical">
-  <meta content="6ce3d22c050ca20ad1c5f87b00cf349620668a9d" name="document-revision">
+  <meta content="17316b7fceb12904d0dc128c291959d865541752" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -744,7 +744,7 @@ activation</a>,
 then <a href="https://html.spec.whatwg.org/multipage/interaction.html#consume-user-activation">consume user
 activation</a> in <var>targetWindow</var>.</p>
       <li data-md>
-       <p>Otherwise, let <var>delegate</var> be null.</p>
+       <p>Otherwise, set <var>delegate</var> to null.</p>
      </ol>
    </ol>
    <h2 class="heading settled" data-level="4" id="tracking-delegation"><span class="secno">4. </span><span class="content">Tracking delegated capability</span><a class="self-link" href="#tracking-delegation"></a></h2>

--- a/spec.html
+++ b/spec.html
@@ -6,7 +6,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version 5c7bc9381, updated Wed May 12 18:18:08 2021 -0700" name="generator">
   <link href="https://wicg.github.io/capability-delegation/spec.html" rel="canonical">
-  <meta content="88e8a2d77121deb145a5c225ab0fd028719992df" name="document-revision">
+  <meta content="6ce3d22c050ca20ad1c5f87b00cf349620668a9d" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -563,7 +563,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Capability Delegation</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2022-01-06">6 January 2022</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2022-01-07">7 January 2022</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -737,7 +737,7 @@ the following step:</p>
      <ol>
       <li data-md>
        <p>If <var>targetOrigin</var> is a single U+002A ASTERISK character (*), then throw a
-a "NotAllowedError" <a data-link-type="dfn">DOMException</a> and return.</p>
+a "NotAllowedError" DOMException.</p>
       <li data-md>
        <p>If <var>targetWindow</var> has <a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">transient
 activation</a>,
@@ -822,7 +822,8 @@ replaced to implement the delegated behavior:</p>
     <ol start="2">
      <li data-md>
       <p>If the relevant global object of request does not have transient
-activation, return a promise rejected with with a "NotAllowedError" <a data-link-type="dfn">DOMException</a>.</p>
+activation, return a promise rejected with with a "NotAllowedError"
+DOMException.</p>
      <li data-md>
       <p>Consume user activation of the relevant global object.</p>
     </ol>
@@ -834,7 +835,7 @@ activation, return a promise rejected with with a "NotAllowedError" <a data-link
 activation</a>,
 AND the timestamp <a data-link-type="dfn" href="#delegated_capability_timestamps" id="ref-for-delegated_capability_timestamps④">DELEGATED_CAPABILITY_TIMESTAMPS</a>["payment"] in the
 relevant global object is either undefined or <a href="https://html.spec.whatwg.org/multipage/interaction.html#activation-expiry">expired</a>,
-then return a promise rejected with with a "NotAllowedError" <a data-link-type="dfn">DOMException</a>.</p>
+then return a promise rejected with with a "NotAllowedError" DOMException.</p>
     <li data-md>
      <p>If the relevant global object of request does not have transient activation,
 then clear the map entry <a data-link-type="dfn" href="#delegated_capability_timestamps" id="ref-for-delegated_capability_timestamps⑤">DELEGATED_CAPABILITY_TIMESTAMPS</a>["payment"].</p>

--- a/spec.html
+++ b/spec.html
@@ -6,7 +6,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version 5c7bc9381, updated Wed May 12 18:18:08 2021 -0700" name="generator">
   <link href="https://wicg.github.io/capability-delegation/spec.html" rel="canonical">
-  <meta content="d36d48aa479bca187d9b7fd929e610ff89ef484f" name="document-revision">
+  <meta content="88e8a2d77121deb145a5c225ab0fd028719992df" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -563,7 +563,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Capability Delegation</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2021-09-13">13 September 2021</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2022-01-06">6 January 2022</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -575,7 +575,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2021 the Contributors to the Capability Delegation Specification, published by the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
+   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2022 the Contributors to the Capability Delegation Specification, published by the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
 A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available. </p>
    <hr title="Separator for header">
   </div>
@@ -736,6 +736,9 @@ the following step:</p>
      <p>If <var>delegate</var> is not null, then:</p>
      <ol>
       <li data-md>
+       <p>If <var>targetOrigin</var> is a single U+002A ASTERISK character (*), then throw a
+a "NotAllowedError" <a data-link-type="dfn">DOMException</a> and return.</p>
+      <li data-md>
        <p>If <var>targetWindow</var> has <a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">transient
 activation</a>,
 then <a href="https://html.spec.whatwg.org/multipage/interaction.html#consume-user-activation">consume user
@@ -819,8 +822,7 @@ replaced to implement the delegated behavior:</p>
     <ol start="2">
      <li data-md>
       <p>If the relevant global object of request does not have transient
-activation, return a promise rejected with with a "NotAllowedError"
-DOMException.</p>
+activation, return a promise rejected with with a "NotAllowedError" <a data-link-type="dfn">DOMException</a>.</p>
      <li data-md>
       <p>Consume user activation of the relevant global object.</p>
     </ol>
@@ -832,7 +834,7 @@ DOMException.</p>
 activation</a>,
 AND the timestamp <a data-link-type="dfn" href="#delegated_capability_timestamps" id="ref-for-delegated_capability_timestamps④">DELEGATED_CAPABILITY_TIMESTAMPS</a>["payment"] in the
 relevant global object is either undefined or <a href="https://html.spec.whatwg.org/multipage/interaction.html#activation-expiry">expired</a>,
-then return a promise rejected with with a "NotAllowedError" DOMException.</p>
+then return a promise rejected with with a "NotAllowedError" <a data-link-type="dfn">DOMException</a>.</p>
     <li data-md>
      <p>If the relevant global object of request does not have transient activation,
 then clear the map entry <a data-link-type="dfn" href="#delegated_capability_timestamps" id="ref-for-delegated_capability_timestamps⑤">DELEGATED_CAPABILITY_TIMESTAMPS</a>["payment"].</p>


### PR DESCRIPTION
When delegating a capability with `targetOrigin` equal to `*`, throw an exception.  Also add valid target origins in the examples.

Closes #14, #17 