### PR TITLE
Prevent delegating a capability that is not available to the source.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -145,16 +145,23 @@ will be followed by two additional steps as follows:
 
 8. If <var>delegate</var> is not null, then:
 
-    1. If <var>targetOrigin</var> is a single U+002A ASTERISK character (*), then throw a
-        a "NotAllowedError" DOMException.
+    1. If <var>targetWindow</var>'s [associated
+        Document](https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window)
+        is not
+        [allowed-to-use](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use)
+        the feature indicated by <var>delegate</var>, then throw a a
+        "NotAllowedError" DOMException.
 
-    2. If <var>targetWindow</var> has [transient
+    2. If <var ignore>targetOrigin</var> is a single U+002A ASTERISK character
+        (*), then throw a a "NotAllowedError" DOMException.
+
+    3. If <var>targetWindow</var> has [transient
         activation](https://html.spec.whatwg.org/multipage/interaction.html#transient-activation),
         then [consume user
         activation](https://html.spec.whatwg.org/multipage/interaction.html#consume-user-activation)
         in <var>targetWindow</var>.
 
-    3. Otherwise, set <var>delegate</var> to null.
+    4. Otherwise, set <var>delegate</var> to null.
 
 
 # Tracking delegated capability # {#tracking-delegation}

--- a/spec.html
+++ b/spec.html
@@ -6,7 +6,7 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version 5c7bc9381, updated Wed May 12 18:18:08 2021 -0700" name="generator">
   <link href="https://wicg.github.io/capability-delegation/spec.html" rel="canonical">
-  <meta content="3e5f77738c8bb0a153e937b3ac50ae12b3e35975" name="document-revision">
+  <meta content="e83d081efbbc816d427ca12db2d6e814f1286915" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -563,7 +563,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Capability Delegation</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2022-01-07">7 January 2022</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2022-01-25">25 January 2022</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -736,8 +736,12 @@ the following step:</p>
      <p>If <var>delegate</var> is not null, then:</p>
      <ol>
       <li data-md>
-       <p>If <var>targetOrigin</var> is a single U+002A ASTERISK character (*), then throw a
-a "NotAllowedError" DOMException.</p>
+       <p>If <var>targetWindow</var>’s <a href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window">associated
+Document</a> is not <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use">allowed-to-use</a> the feature indicated by <var>delegate</var>, then throw a a
+"NotAllowedError" DOMException.</p>
+      <li data-md>
+       <p>If <var>targetOrigin</var> is a single U+002A ASTERISK character
+(*), then throw a a "NotAllowedError" DOMException.</p>
       <li data-md>
        <p>If <var>targetWindow</var> has <a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">transient
 activation</a>,


### PR DESCRIPTION
If delegation source does not have the permission to use the feature it is
trying to delegate, the `postMessage()` fires exception.

Closes #3.