### PR TITLE
Update README and examples for M100+

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,13 @@ the two examples above, the restricted APIs are `payment_request.show()` and
 ### Demo
 
 To see how this API works with Payment Request, run Chrome 93 or newer with the
-command-line flag `--enable-blink-features=CapabilityDelegationPaymentRequest`,
-then open [this
+below version-dependent command-line flag, then open [this
 demo](https://wicg.github.io/capability-delegation/example/payment-request/).
 
+Flag:
+
+- Version 93-99: `--enable-blink-features=CapabilityDelegationPaymentRequest`
+- Version 100+: `--enable-blink-features=PaymentRequestRequiresUserActivation`
 
 ## Related links
 

--- a/example/payment-request/index.html
+++ b/example/payment-request/index.html
@@ -6,7 +6,7 @@
     <title>Payment request example</title>
     <script>
       function init() {
-          let target_origin = "https://egirard.github.io";
+          let target_origin = "https://stephenmcgruer.github.io";
 
           document.getElementById("button0").addEventListener("click", e => {
               frames[0].postMessage("checkout", {targetOrigin: target_origin});
@@ -38,8 +38,12 @@
   </head>
   <body onload="init()">
     <h1>Test shopping cart</h1>
-    <small>This demo requires Chrome 93 or newer, and with the command-line flag
-      <code>--enable-blink-features=CapabilityDelegationPaymentRequest</code>.</small>
+    <small>This demo requires Chrome 93 or newer, and requires a version-dependent command-line flag:
+      <ul>
+        <li>Version 93-99<code>--enable-blink-features=CapabilityDelegationPaymentRequest</code></li>
+        <li>Version 100+<code>--enable-blink-features=PaymentRequestRequiresUserActivation</code></li>
+      </ul>
+    </small>
     <small>Exactly one of the following buttons should show a payment dialog.</small>
     <div id="cart">
       <span>3 items, $10.00</span><br>
@@ -51,7 +55,7 @@
     </div>
     <iframe
       id="iframe"
-      src="https://egirard.github.io/capability-delegation-example/payment-request/"
+      src="https://stephenmcgruer.github.io/capability-delegation-example/payment-request/"
       allow="payment">
     </iframe>
   </body>

--- a/example/payment-request/index.html
+++ b/example/payment-request/index.html
@@ -6,7 +6,7 @@
     <title>Payment request example</title>
     <script>
       function init() {
-          let target_origin = "https://humble-lava-beauty.glitch.me/";
+          let target_origin = "https://egirard.github.io";
 
           document.getElementById("button0").addEventListener("click", e => {
               frames[0].postMessage("checkout", {targetOrigin: target_origin});
@@ -55,7 +55,7 @@
     </div>
     <iframe
       id="iframe"
-      src="https://humble-lava-beauty.glitch.me/"
+      src="https://egirard.github.io/capability-delegation-example/payment-request/"
       allow="payment">
     </iframe>
   </body>

--- a/example/payment-request/index.html
+++ b/example/payment-request/index.html
@@ -6,7 +6,7 @@
     <title>Payment request example</title>
     <script>
       function init() {
-          let target_origin = "https://stephenmcgruer.github.io";
+          let target_origin = "https://humble-lava-beauty.glitch.me/";
 
           document.getElementById("button0").addEventListener("click", e => {
               frames[0].postMessage("checkout", {targetOrigin: target_origin});
@@ -55,7 +55,7 @@
     </div>
     <iframe
       id="iframe"
-      src="https://stephenmcgruer.github.io/capability-delegation-example/payment-request/"
+      src="https://humble-lava-beauty.glitch.me/"
       allow="payment">
     </iframe>
   </body>

--- a/example/payment-request/same-origin-subframe.html
+++ b/example/payment-request/same-origin-subframe.html
@@ -7,10 +7,7 @@
     <script>
       const requestPayment = async e => {
           const request = new PaymentRequest([{
-              supportedMethods: "basic-card",
-              data: {
-                  supportedNetworks: ["visa", "master", "amex"]
-              }
+              supportedMethods: "https://bobbucks.dev/pay",
           }], {
               total: {
                   label: "total",

--- a/example/payment-request/same-origin.html
+++ b/example/payment-request/same-origin.html
@@ -33,8 +33,12 @@
   </head>
   <body onload="init()">
     <h1>Test shopping cart</h1>
-    <small>This demo requires Chrome 93 or newer, and with the command-line flag
-      <code>--enable-blink-features=CapabilityDelegationPaymentRequest</code>.</small>
+    <small>This demo requires Chrome 93 or newer, and requires a version-dependent command-line flag:
+      <ul>
+        <li>Version 93-99<code>--enable-blink-features=CapabilityDelegationPaymentRequest</code></li>
+        <li>Version 100+<code>--enable-blink-features=PaymentRequestRequiresUserActivation</code></li>
+      </ul>
+    </small>
     <small>Exactly one of the following buttons should show a payment dialog.</small>
     <div id="cart">
       <span>3 items, $10.00</span><br>


### PR DESCRIPTION
M100 brings two relevant changes:
    
1. basic-card is deprecated, and so we switch to using the test payment app
       https://bobbucks.dev/ instead.
2. We changed the name of the flag for enforcing user-activation for
       PaymentRequest.show()