### PR TITLE
If both are available, consume delegated fullscreen capability and transient activation in one step

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -919,20 +919,25 @@ relevant global object is neither undefined nor <a href="https://html.spec.whatw
 the algorithm is triggered by a user generated orientation change.</p>
      </ul>
    </ol>
-   <p>Right before the Step 10:</p>
+   <p>Step 6:</p>
    <blockquote>
-    <ol start="10">
+    <ol start="6">
      <li data-md>
-      <p>Let fullscreenElements be an ordered set initially consisting of this.</p>
+      <p>If <var>error</var> is false, then consume user activation given <var>pendingDoc</var>'s
+      relevant global object.</p>
     </ol>
    </blockquote>
-   <p>the following new step will be inserted:</p>
-   <ol start="10">
+   will be replaced by two steps:
+   <ol start="6">
     <li data-md>
-     <p>If this’s relevant global object does not have transient activation, then clear the map entry <a data-link-type="dfn" href="#delegated_capability_timestamps" id="ref-for-delegated_capability_timestamps⑦">DELEGATED_CAPABILITY_TIMESTAMPS</a>["fullscreen"] in this’s relevant global object.</p>
+     <p>If <var>error</var> is false and this’ relevant global object does not have
+     transient activation, then clear the map entry <a data-link-type="dfn"
+     href="#delegated_capability_timestamps" id="ref-for-delegated_capability_timestamps⑦"
+     >DELEGATED_CAPABILITY_TIMESTAMPS</a>["fullscreen"] in this’ relevant global object.</p>
     <li data-md>
-     <p>Let fullscreenElements be an ordered set initially consisting of this. <em>(unchanged except
- for numbering)</em></p>
+     <p>Otherwise, if <var>error</var> is false,
+     <a href="https://html.spec.whatwg.org/multipage/interaction.html#consume-user-activation"
+     >consume user activation</a> of the relevant global object.</p>
    </ol>
    <h3 class="heading settled" data-level="5.3" id="monkey-patch-to-screen-capture"><span class="secno">5.3. </span><span class="content">Monkey-patch to <a data-link-type="biblio" href="#biblio-screen-capture" title="Screen Capture">[SCREEN-CAPTURE]</a> spec</span><a class="self-link" href="#monkey-patch-to-screen-capture"></a></h3>
    <p>In the algorithm for <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/mediacapture-screen-share/#dom-mediadevices-getdisplaymedia" id="ref-for-dom-mediadevices-getdisplaymedia">getDisplayMedia()</a></code>, the following changes will be

--- a/spec.html
+++ b/spec.html
@@ -927,17 +927,22 @@ the algorithm is triggered by a user generated orientation change.</p>
       relevant global object.</p>
     </ol>
    </blockquote>
-   will be replaced by two steps:
+   will be replaced by:
    <ol start="6">
-    <li data-md>
-     <p>If <var>error</var> is false and this’ relevant global object does not have
-     transient activation, then clear the map entry <a data-link-type="dfn"
-     href="#delegated_capability_timestamps" id="ref-for-delegated_capability_timestamps⑦"
-     >DELEGATED_CAPABILITY_TIMESTAMPS</a>["fullscreen"] in this’ relevant global object.</p>
-    <li data-md>
-     <p>Otherwise, if <var>error</var> is false,
-     <a href="https://html.spec.whatwg.org/multipage/interaction.html#consume-user-activation"
-     >consume user activation</a> of the relevant global object.</p>
+    <li data-md><p>If <var>error</var> is false:</p>
+     <ol>
+      <li data-md>
+       <p>Clear the map entry <a data-link-type="dfn"
+       href="#delegated_capability_timestamps" id="ref-for-delegated_capability_timestamps⑦"
+       >DELEGATED_CAPABILITY_TIMESTAMPS</a>["fullscreen"] in this’
+       <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global"
+       >relevant global object</a>.</p>
+      <li data-md>
+       <a href="https://html.spec.whatwg.org/multipage/interaction.html#consume-user-activation"
+       >Consume user activation</a> given <var>pendingDoc</var>'s'
+       <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global"
+       >relevant global object</a>.</p>
+     </ol>
    </ol>
    <h3 class="heading settled" data-level="5.3" id="monkey-patch-to-screen-capture"><span class="secno">5.3. </span><span class="content">Monkey-patch to <a data-link-type="biblio" href="#biblio-screen-capture" title="Screen Capture">[SCREEN-CAPTURE]</a> spec</span><a class="self-link" href="#monkey-patch-to-screen-capture"></a></h3>
    <p>In the algorithm for <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/mediacapture-screen-share/#dom-mediadevices-getdisplaymedia" id="ref-for-dom-mediadevices-getdisplaymedia">getDisplayMedia()</a></code>, the following changes will be


### PR DESCRIPTION
In reference to #37, I suggest to make the monkey patch to the Fullscreen API more similar to the one for the Payment Request API in one way:
- ~~Do not consume both transient activation and delegated capability, rather consume only the former if available. This is analogous to the behavior for Payment Request API.~~
- Consume the delegated capability at the same time where the transient activation would be consumed and not in parallel with returning a promise. This avoids race conditions.