### PR TITLE
Use the current time before queueing a task as delegated capability timestamp

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -806,30 +806,31 @@ a new paragraph will be inserted, as follow:</p>
     <p>For the purpose of tracking capabilities delegated to a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context" id="ref-for-browsing-context①①">browsing context</a>,
 each <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window" id="ref-for-window②">Window</a></code> has a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map">map</a> called <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="delegated_capability_timestamps">DELEGATED_CAPABILITY_TIMESTAMPS</dfn> from <a href="https://w3c.github.io/webappsec-permissions-policy/#ascii-serialization">feature-identifier</a> to <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/hr-time/#dom-domhighrestimestamp" id="ref-for-dom-domhighrestimestamp②">DOMHighResTimeStamp</a></code>.  The map is initialized with an empty map.</p>
    </blockquote>
-   <p>In the algorithm for <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#window-post-message-steps">window post
-message</a>,
-two additional sub-steps will be added to current Step 8.  The first additional
-sub-step will be inserted after the following sub-step:</p>
+   <p>
+    In the algorithm for
+    <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#window-post-message-steps"
+    >window post message</a>, the following step:</p>
    <blockquote>
-    <ol start="8">
+    <ol start="6">
      <li data-md>
-      <p>Queue a global task ...</p>
-      <ol start="2">
-       <li data-md>
-        <p>Let origin be the serialization of incumbentSettings’s origin.</p>
-      </ol>
+      <p>Let <var>transfer</var> be <var>options</var>["transfer"].</p>
     </ol>
    </blockquote>
-   <p>as follows:</p>
-   <ol start="8">
+   <p>will now be followed by three additional steps as follows:</p>
+   <ol start="7">
     <li data-md>
-     <p>Queue a global task ... <em>(unchanged)</em></p>
-     <ol start="3">
-      <li data-md>
-       <p>Let <var>delegate</var> be <var>options</var>["delegate"].</p>
-     </ol>
+     <p>Let <var>delegate</var> be <var>options</var>["delegate"]. <em>(unchanged)</em></p>
+    <li data-md>
+     <p>Let <var>currentTime</var> be
+     <a href="https://w3c.github.io/hr-time/#dfn-current-high-resolution-time"
+     >current high resolution time</a>.</p>
+    <li data-md>
+     <p>If <var>delegate</var> is not null, then: ... (unchanged, except for numbering)</p>
    </ol>
-   <p>The second additional sub-step will be inserted after the following sub-step:</p>
+   <p>In the algorithm for
+    <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#window-post-message-steps"
+    >window post message</a>, one additional sub-step will be added to current Step 8 after the
+    following sub-step:</p>
    <blockquote>
     <ol start="8">
      <li data-md>
@@ -841,18 +842,17 @@ sub-step will be inserted after the following sub-step:</p>
     </ol>
    </blockquote>
    <p>as follows:</p>
-   <ol start="8">
+   <ol start="11">
     <li data-md>
-     <p>Queue a global task ... <em>(unchanged)</em></p>
+     <p>Queue a global task ... <em>(unchanged except for numbering)</em></p>
      <ol start="7">
       <li data-md>
        <p>Let newPorts be a new frozen array consisting of ... <em>(unchanged except
 for numbering)</em></p>
       <li data-md>
        <p>If <var>delegate</var> is not null, AND the user agent supports
-delegating <var>delegate</var>, then set <a data-link-type="dfn" href="#delegated_capability_timestamps" id="ref-for-delegated_capability_timestamps②">DELEGATED_CAPABILITY_TIMESTAMPS</a>[<var>delegate</var>] to <a href="https://w3c.github.io/hr-time/#dfn-current-high-resolution-time">current
-high resolution
-time</a>.</p>
+delegating <var>delegate</var>, then set <a data-link-type="dfn" href="#delegated_capability_timestamps" id="ref-for-delegated_capability_timestamps②">DELEGATED_CAPABILITY_TIMESTAMPS</a>[<var>delegate</var>] to
+<var>currentTime</var>.</p>
      </ol>
    </ol>
    <h2 class="heading settled" data-level="5" id="defining-delegated-behavior"><span class="secno">5. </span><span class="content">Defining delegated capability behavior</span><a class="self-link" href="#defining-delegated-behavior"></a></h2>


### PR DESCRIPTION
In reference to https://github.com/WICG/capability-delegation/issues/36, I suggest the [current high resolution time](https://w3c.github.io/hr-time/#dfn-current-high-resolution-time) is stored in a variable before a global task is queued.